### PR TITLE
remove dead Coursera link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Please feel free to [pull requests](https://github.com/keonkim/awesome-nlp/pulls
 
 ### videos
 
-* [Stanford's Coursera Course](https://www.coursera.org/learn/nlp) on NLP from basics
 * [Intro to Natural Language Processing](https://www.coursera.org/learn/natural-language-processing) on Coursera by U of Michigan
 * [Intro to Artificial Intelligence](https://www.udacity.com/course/intro-to-artificial-intelligence--cs271) course on Udacity which also covers NLP
 * [Deep Learning for Natural Language Processing (2015 classes)](https://www.youtube.com/playlist?list=PLmImxx8Char8dxWB9LRqdpCTmewaml96q) by Richard Socher


### PR DESCRIPTION
This WAS the best NLP course so far. I had the lucky chance of going through half of it. Sadly, there is no way of getting coursera to open up the resources for the previous courses... I had a long talk with coursera support. Their answer:

"... I completely understand that you want the content of the course you took in our old platform. Unfortunately, I am afraid that we would not be able to give you access to that material anymore. ..."

PS. Instead of wasting your time on https://www.coursera.org/learn/natural-language-processing  on Coursera by U of Michigan, try to get your hands on the material by Michael Collins http://www.cs.columbia.edu/~mcollins/